### PR TITLE
PMNGIOS-978 [platform] Fix visibility warning, remove not needed armv7 arch and update to OpenCV 4.6.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,7 @@ build_3_4_6:
 
 build_4_5_2:
 	Scripts/opencv_xcframework.sh build_4_5_2
+
+build_4_6_0:
+	Scripts/opencv_xcframework.sh build_4_6_0
+

--- a/opencv2.json
+++ b/opencv2.json
@@ -1,3 +1,0 @@
-{
-    "4.5.2": "https://github.com/revolut-mobile/opencv-binary/releases/download/4.5.2/opencv2.xcframework.zip"
-}


### PR DESCRIPTION
IN THIS PR:
* Fix visibility warning and update to OpenCV 4.6.0

Details:
* Removed `opencv2.json` as we do not need it for integration anymore. Will switch to use bazel for that instead of carthage