### PR TITLE
PMNGIOS-978 [platform] Bring back opencv2.json

### DIFF
--- a/opencv2.json
+++ b/opencv2.json
@@ -1,0 +1,4 @@
+{
+    "4.5.2": "https://github.com/revolut-mobile/opencv-binary/releases/download/4.5.2/opencv2.xcframework.zip",
+    "4.6.0": "https://github.com/revolut-mobile/opencv-binary/releases/download/4.6.0/opencv2.xcframework.zip"
+}


### PR DESCRIPTION
IN THIS PR:
* Bring back opencv2.json

Context: It is needed here, otherwise carthage is not able to resolve the dependency graph properly: https://github.com/revolut-mobile/card.io-iOS-source/blob/7ec026b81d3b28591542db144e69f52f36a1157b/Cartfile#L1