### PR TITLE
PMNG-6541 [platform] Bring back imgwarp

### DIFF
--- a/scripts/opencv_xcframework.sh
+++ b/scripts/opencv_xcframework.sh
@@ -26,9 +26,6 @@ build_xcframework_excluding_modules_4_9_0() {
     readonly VERSION="4.9.0"
 
     # Baseline of which modules to include, obtained from https://github.com/nihui/opencv-mobile/tree/master?tab=readme-ov-file#opencv-modules-included
-
-    # Remove below big files that Revolut does not use
-    find "${BUILD_DIR}/${VERSION}/modules/imgproc/src" -maxdepth 1 -type f -name 'imgwarp*' -delete # Delete 691KB of the final release binary
     
     python3 "${BUILD_DIR}/${VERSION}/platforms/apple/build_xcframework.py" \
         --build_only_specified_archs \


### PR DESCRIPTION
Bring back imgwarp. I was too optimistic about removing it 😄 Got this error while trying to integrate:
```
ld: Undefined symbols:
 cv::convertMaps(cv::_InputArray const&, cv::_InputArray const&, cv::_OutputArray const&, cv::_OutputArray const&, int, bool), referenced from:
cv::initWideAngleProjMap(cv::_InputArray const&, cv::_InputArray const&, cv::Size_<int>, int, int, cv::_OutputArray const&, cv::_OutputArray const&, cv::UndistortTypes, double) in opencv2[arm64][44](undistort.dispatch.o)
 cv::remap(cv::_InputArray const&, cv::_OutputArray const&, cv::_InputArray const&, cv::_InputArray const&, int, int, cv::Scalar_<double> const&), referenced from:
cv::undistort(cv::_InputArray const&, cv::_OutputArray const&, cv::_InputArray const&, cv::_InputArray const&, cv::_InputArray const&) in opencv2[arm64][44](undistort.dispatch.o)
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```

`convertMaps` and `remap` are defined inside `imgwarp.cpp`